### PR TITLE
Update mixin to support Minecraft 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.21.1
-	yarn_mappings=1.21.1+build.3
-	loader_version=0.16.3
+	minecraft_version=1.21.4
+	yarn_mappings=1.21.4+build.1
+	loader_version=0.16.9
 
 # Mod Properties
 	mod_version = 1.0.1

--- a/src/main/java/qu/noshielddelay/mixin/LivingEntityMixin.java
+++ b/src/main/java/qu/noshielddelay/mixin/LivingEntityMixin.java
@@ -9,8 +9,8 @@ import qu.noshielddelay.config.ModConfig;
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
 
-    //Injects into the isBlocking method and changes the 5 constant to whatever ModConfig.DELAY is.
-    @ModifyConstant(method = "isBlocking", constant = @Constant(intValue = 5))
+    //Injects into the getBlockingItem method and changes the 5 constant to whatever ModConfig.DELAY is.
+    @ModifyConstant(method = "getBlockingItem", constant = @Constant(intValue = 5))
     private int setShieldUseDelay(int constant) {
         return ModConfig.ENABLED ? ModConfig.DELAY : constant;
     }


### PR DESCRIPTION
It seems like Mojang changed the location of the default delay constant again, this PR should fix that.

Changes:

- update mappings to 1.21.4
- fix mixin to find the correct constant again
- should close #9 and #10, but I only tested it with MC 1.21.4